### PR TITLE
Change gyp to gn

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -154,10 +154,10 @@ design is quite clever.
 Ninja's benefit comes from using it in conjunction with a smarter
 meta-build system.
 
-http://code.google.com/p/gyp/[gyp]:: The meta-build system used to
+https://gn.googlesource.com/gn/[gn]:: The meta-build system used to
 generate build files for Google Chrome and related projects (v8,
-node.js).  gyp can generate Ninja files for all platforms supported by
-Chrome. See the
+node.js), as well as Google Fuschia.  gn can generate Ninja files for
+all platforms supported by Chrome. See the
 https://chromium.googlesource.com/chromium/src/+/master/docs/ninja_build.md[Chromium Ninja documentation for more details].
 
 https://cmake.org/[CMake]:: A widely used meta-build system that


### PR DESCRIPTION
Chrome has switched from gyp to gn, and Fuschia also uses it now.

Note that the "Chromium Ninja documentation" link is dead, but I'm not sure what to replace it with. The closest I've found is https://chromium.googlesource.com/experimental/chromium/src/+/refs/wip/bajones/webvr/docs/ninja_build.md, but I'm not sure that's the original intended target.